### PR TITLE
Change folder name in JFR tarballs

### DIFF
--- a/build-openjdk8.sh
+++ b/build-openjdk8.sh
@@ -5,6 +5,8 @@ UPDATE=262
 BUILD=b01
 NAME="openjdk-8u${UPDATE}-${BUILD}"
 JRE_NAME="${NAME}-jre"
+JFR_NAME="\${NAME}-jfr"
+JFR_JRE_NAME="\${JRE_NAME}-jfr"
 TARBALL_BASE_NAME="OpenJDK8U"
 EA_SUFFIX="_ea"
 PLATFORM="x64_linux"
@@ -71,6 +73,8 @@ build() {
     if [ "${debug}_" == "release-jfr_" ]; then
       archive_name="$TARBALL_NAME_JFR"
       jre_archive_name="$TARBALL_NAME_JFR_JRE"
+      NAME=$JFR_NAME
+      JRE_NAME=$JFR_JRE_NAME
     fi
     # Package it up
     pushd build/$debug/images

--- a/install-rhel6-deps-build-openjdk8.sh
+++ b/install-rhel6-deps-build-openjdk8.sh
@@ -77,6 +77,8 @@ UPDATE=262
 BUILD=b01
 NAME="openjdk-8u\${UPDATE}-\${BUILD}"
 JRE_NAME="\${NAME}-jre"
+JFR_NAME="\${NAME}-jfr"
+JFR_JRE_NAME="\${JRE_NAME}-jfr"
 TARBALL_BASE_NAME="OpenJDK8U"
 EA_SUFFIX="_ea"
 PLATFORM="x64_linux"
@@ -162,6 +164,8 @@ build() {
     if [ "\${debug}_" == "release-jfr_" ]; then
       archive_name="\$TARBALL_NAME_JFR"
       jre_archive_name="\$TARBALL_NAME_JFR_JRE"
+      NAME="\$JFR_NAME"
+      JRE_NAME="\$JFR_JRE_NAME"
     fi
     # Package it up
     pushd build/\$debug/images


### PR DESCRIPTION
Previously the folder names were as follows:

OpenJDK8U-jre-jfr_x64_linux_8u262b01_ea.tar.gz =>
openjdk-8u262-b01-jre

OpenJDK8U-jdk-jfr_x64_linux_8u262b01_ea.tar.gz =>
openjdk-8u262-b01

Note these conflict with regular, non-JFR-enabled tarballs:

OpenJDK8U-jre_x64_linux_8u262b01_ea.tar.gz =>
openjdk-8u262-b01-jre

OpenJDK8U-jdk_x64_linux_8u262b01_ea.tar.gz =>
openjdk-8u262-b01

This changes JFR folders to the following:
openjdk-8u262-b01-jre => openjdk-8u262-b01-jre-jfr
openjdk-8u262-b01 => openjdk-8u262-b01-jfr