### PR TITLE
Improve Windows file permissions handling

### DIFF
--- a/build8.cmd
+++ b/build8.cmd
@@ -426,7 +426,6 @@
 	set m2=
 	set m3=
 	set m4=
-	set m5=
 	set modules=
 	if not exist %WORK_DIR%/ojdkbuild (
 		set OJDKBUILD_REPO=%OJDKBUILD_REPOBASE%/ojdkbuild.git
@@ -443,9 +442,6 @@
 		set m2=tools/bootjdk7 tools/cmake tools/cygwin_jdk11 tools/make tools/zip
 	)
 	set m3=tools/toolchain/directx tools/toolchain/msvcr100 tools/toolchain/sdk71 tools/toolchain/vs2010e
-	if defined WITH_JTREG (
-		set m5=tools/jtreg42_653
-	)
 	set modules=%m1% %m2% %m3% %m4% %m5%
 	if not exist %OJDKBUILD_DIR%/deps      mkdir %OJDKBUILD_DIR:/=\%\deps
 	if not exist %OJDKBUILD_DIR%/external  mkdir %OJDKBUILD_DIR:/=\%\external

--- a/build8.cmd
+++ b/build8.cmd
@@ -9,7 +9,7 @@
 		set spec_dir=
 		set WORK_DIR=
 		set JAVA_HOME=
-		set EA_SUFFIX="_ea"
+		set EA_SUFFIX=
 		set DEV_REPO=
 		set DOWNLOAD_TOOLS=1
 		set DOWNLOAD_JDK=1
@@ -28,8 +28,8 @@
 	set BUILD=b02
 	set MILESTONE=redhat
 	set OJDK_MILESTONE=8u
-	set OJDK_UPDATE=332
-	set OJDK_BUILD=b02
+	set OJDK_UPDATE=%UPDATE%
+	set OJDK_BUILD=%BUILD%
 	set OJDK_TAG=jdk%OJDK_MILESTONE%%OJDK_UPDATE%-%OJDK_BUILD%
 	set EA_SUFFIX="_ea"
 
@@ -143,7 +143,7 @@
 	if defined BUILD_JDK (
 		call :build_jdk || exit /b 1
 		time /t
-		rem call :test_jdk_version || exit /b 1
+		call :test_jdk_version
 		if defined PACKAGE_RELEASE (
 			call :build_jdk_zip || exit /b 1
 		)
@@ -237,9 +237,11 @@
 	icacls "%OJDK_SRC_PATH:/=\%" /reset /T /C /Q || exit /b 1
 	@echo off
 	rem print out the SCS ID of what we are building
+	call :setsdkenv
 	@echo *** current SCS changeset
 	pushd "%OJDK_SRC_PATH%"
 	%GIT% log -1
+
 	popd
 	exit /b 0
 
@@ -552,7 +554,4 @@
 	set PATH=%PATH%;%OJDKBUILD_DIR%/tools/make
 	set PATH=%PATH%;%OJDKBUILD_DIR%/tools/perl520/perl/bin
 	set PATH=%PATH%;%OJDKBUILD_DIR%/resources/scripts
-	set PATH=%PATH%;C:/cygwin64/bin
-	
 	exit /b 0
-


### PR DESCRIPTION
This PR updates the file permissions in the checked out OpenJDK repo.  

The Cygwin64 git does not create files with proper Windows file permissions when it clones a remote repository.
This PR reworks the code that fixes those permissions.

After this PR is merged, the upstream OpenJDK8u builds run without issue.

